### PR TITLE
launch: route hardware baseline through command_safe by default

### DIFF
--- a/seano_ca_ws/src/seano_vision/launch/phase7_cuav_usb_hardware.launch.py
+++ b/seano_ca_ws/src/seano_vision/launch/phase7_cuav_usb_hardware.launch.py
@@ -645,8 +645,8 @@ def generate_launch_description():
         DeclareLaunchArgument("ca_risk_topic", default_value="/ca/risk"),
         DeclareLaunchArgument(
             "ca_command_topic",
-            default_value="/ca/command",
-            description="Default hardware disatukan ke /ca/command. Override ke /ca/command_safe hanya bila memang disengaja.",
+            default_value="/ca/command_safe",
+            description="Default hardware mengikuti watchdog-conditioned command stream (/ca/command_safe). Override ke /ca/command hanya untuk debugging atau eksperimen terkontrol.",
         ),
         DeclareLaunchArgument("ca_mode_topic", default_value="/ca/mode"),
         DeclareLaunchArgument("ca_metrics_topic", default_value="/ca/metrics"),


### PR DESCRIPTION
## Summary
Describe the change clearly in 1-3 sentences.

## Related issue
- Closes #
- Related to #

## Target baseline
- [ ] Simulation baseline (SITL + MAVROS + Mission Planner)
- [ ] Hardware baseline (Jetson + CUAV X7+ + USB camera)
- [ ] Repository / CI / documentation only

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] CI / tooling update
- [ ] Launch / integration update

## Scope
What is included in this PR?
What is intentionally out of scope?

## Files or components changed
- Node(s):
- Launch file(s):
- Topic/interface(s):
- Script/tooling:
- Documentation:

## Validation performed
Describe exactly how this was tested.

### Simulation validation
- [ ] Not applicable
- [ ] Build completed
- [ ] Launch completed
- [ ] Mission flow checked
- [ ] Avoid / rejoin behavior checked
- [ ] Logs reviewed

Command(s) used:
```bash
# paste commands here
````

### Hardware bench validation

* [ ] Not applicable
* [ ] Build completed on target device
* [ ] Camera stream verified
* [ ] Detection pipeline verified
* [ ] Risk evaluator verified
* [ ] Watchdog / safety behavior checked
* [ ] Browser monitoring verified

Command(s) used:

```bash
# paste commands here
```

## Evidence

* Screenshot / recording:
* Log excerpt:
* Topic snapshot:
* Metrics / result summary:
* Related document:

## Documentation update

* [ ] README updated
* [ ] RUNBOOK updated
* [ ] ARCHITECTURE updated
* [ ] LAUNCH_STATUS_MAP updated
* [ ] HARDWARE_BENCH_RESULTS updated
* [ ] No documentation update needed

## Risk and rollback

What could break because of this change?
How can it be reverted safely if needed?

## Checklist

* [ ] I tested the change before opening this PR
* [ ] I kept the scope focused
* [ ] I updated affected documentation
* [ ] I did not include unrelated formatting-only edits
* [ ] I reviewed logs, warnings, or obvious runtime regressions
